### PR TITLE
perf: batch relation loading, reflection caching, UUID FK fix

### DIFF
--- a/src/Repository/EntityHelper.php
+++ b/src/Repository/EntityHelper.php
@@ -34,6 +34,30 @@ abstract class EntityHelper
     /** @var array<string, array<string>> $tableColumnsCache */
     protected array $tableColumnsCache = [];
 
+    // ── Reflection caches (static — shared across all repository instances) ──
+    /** @var array<string, ReflectionClass> */
+    protected static array $reflClassCache = [];
+    /** @var array<string, ReflectionProperty> */
+    protected static array $reflPropCache = [];
+
+    /**
+     * Get a cached ReflectionClass instance.
+     */
+    protected static function reflect(string|object $class): ReflectionClass
+    {
+        $key = is_object($class) ? get_class($class) : $class;
+        return self::$reflClassCache[$key] ??= new ReflectionClass($key);
+    }
+
+    /**
+     * Get a cached ReflectionProperty instance.
+     */
+    protected static function reflectProp(string|object $class, string $prop): ReflectionProperty
+    {
+        $key = (is_object($class) ? get_class($class) : $class) . '::' . $prop;
+        return self::$reflPropCache[$key] ??= new ReflectionProperty($class, $prop);
+    }
+
     protected static array $reservedIdents = [
         'key',
         'keys',
@@ -59,7 +83,7 @@ abstract class EntityHelper
             return;
         }
 
-        $idProp = new ReflectionProperty($entity, 'id');
+        $idProp = self::reflectProp($entity, 'id');
 
         if (!$idProp->isInitialized($entity)) {
             return;
@@ -124,7 +148,7 @@ abstract class EntityHelper
 
     protected function assertRelationsAreSerialized(object $entity, array $data): void
     {
-        $ref = new \ReflectionClass($entity);
+        $ref = self::reflect($entity);
 
         foreach ($ref->getProperties() as $prop) {
             $attrs = $prop->getAttributes(\MonkeysLegion\Entity\Attributes\ManyToOne::class);
@@ -209,7 +233,7 @@ abstract class EntityHelper
     protected function extractPersistableData(object $entity): array
     {
         $data = [];
-        $ref = new ReflectionClass($entity);
+        $ref = self::reflect($entity);
 
         foreach ($ref->getProperties() as $prop) {
             if (!$prop->isInitialized($entity)) {
@@ -245,7 +269,7 @@ abstract class EntityHelper
                     }
                 } else {
                     // Get the ID of the related entity
-                    $idProp = new ReflectionProperty($relatedEntity, 'id');
+                    $idProp = self::reflectProp($relatedEntity, 'id');
                     $data[$columnName] = $idProp->getValue($relatedEntity);
                 }
             }
@@ -268,7 +292,7 @@ abstract class EntityHelper
                         $data[$columnName] = null;
                     } else {
                         // Get the ID of the related entity
-                        $idProp = new ReflectionProperty($relatedEntity, 'id');
+                        $idProp = self::reflectProp($relatedEntity, 'id');
                         $data[$columnName] = $idProp->getValue($relatedEntity);
                     }
                 }
@@ -372,7 +396,7 @@ abstract class EntityHelper
     protected function getJoinTableMeta(string $relationProp, ?object $entity = null): array
     {
         $className = $entity ? get_class($entity) : $this->entityClass;
-        $ownClass = new ReflectionClass($className);
+        $ownClass = self::reflect($className);
 
         if (!$ownClass->hasProperty($relationProp)) {
             throw new InvalidArgumentException("Property {$relationProp} not found on {$className}");
@@ -398,7 +422,7 @@ abstract class EntityHelper
                     "Relation {$relationProp} has no joinTable or mappedBy/inversedBy"
                 );
 
-            $otherClass = new ReflectionClass($meta->targetEntity);
+            $otherClass = self::reflect($meta->targetEntity);
             if (!$otherClass->hasProperty($otherProp)) {
                 throw new InvalidArgumentException("Property {$otherProp} not found on {$meta->targetEntity}");
             }
@@ -437,7 +461,7 @@ abstract class EntityHelper
     protected function getEntityId(object $entity): ?string
     {
         if (property_exists($entity, 'id')) {
-            $idProp = new ReflectionProperty($entity, 'id');
+            $idProp = self::reflectProp($entity, 'id');
             return $idProp->isInitialized($entity) ? (string) $idProp->getValue($entity) : null;
         }
         return null;
@@ -449,7 +473,7 @@ abstract class EntityHelper
     protected function getEntityPropValue(object $entity, string $propName): mixed
     {
         if (property_exists($entity, $propName)) {
-            $prop = new ReflectionProperty($entity, $propName);
+            $prop = self::reflectProp($entity, $propName);
             return $prop->isInitialized($entity) ? $prop->getValue($entity) : null;
         }
         return null;
@@ -458,28 +482,34 @@ abstract class EntityHelper
     /**
      * @throws \ReflectionException
      */
+    /** @var array<string, string> */
+    protected static array $tableOfCache = [];
+
     protected function tableOf(string $entityClass): string
     {
+        if (isset(self::$tableOfCache[$entityClass])) {
+            return self::$tableOfCache[$entityClass];
+        }
+
         // ① explicit constant on the entity
         if (defined("$entityClass::TABLE")) {
-            return $entityClass::TABLE;
+            return self::$tableOfCache[$entityClass] = $entityClass::TABLE;
         }
 
         // ② `$table` default on the repository stub
         $repoClass = str_replace('\\Entity\\', '\\Repository\\', $entityClass) . 'Repository';
         if (class_exists($repoClass)) {
-            $rc = new \ReflectionClass($repoClass);
+            $rc = self::reflect($repoClass);
             if ($rc->hasProperty('table')) {
-                // read the *default* value without building an object
-                $defaults = $rc->getDefaultProperties();      // PHP ≥7.4
+                $defaults = $rc->getDefaultProperties();
                 if (!empty($defaults['table'])) {
-                    return (string) $defaults['table'];
+                    return self::$tableOfCache[$entityClass] = (string) $defaults['table'];
                 }
             }
         }
 
         // ③ fallback rule (lower-case short name)
-        return strtolower(new \ReflectionClass($entityClass)->getShortName());
+        return self::$tableOfCache[$entityClass] = strtolower(self::reflect($entityClass)->getShortName());
     }
 
     /**
@@ -496,7 +526,7 @@ abstract class EntityHelper
         // Ensure $id is a string for consistent handling
         $id = (string) $id;
 
-        $rc = new \ReflectionClass($this->entityClass);
+        $rc = self::reflect($this->entityClass);
         $pdo = $this->qb->pdo();
 
         // Use QueryBuilder's quoteIdentifier (Identifier trait) — it auto-detects
@@ -689,7 +719,7 @@ abstract class EntityHelper
         }
 
         // if $key is a property on the entity and it's a relation, convert to FK
-        $rc = new \ReflectionClass($this->entityClass);
+        $rc = self::reflect($this->entityClass);
         if ($rc->hasProperty($key)) {
             $prop = $rc->getProperty($key);
 
@@ -744,7 +774,7 @@ abstract class EntityHelper
         if (is_object($value)) {
             // extract id if present
             if (property_exists($value, 'id')) {
-                $rp = new \ReflectionProperty($value, 'id');
+                $rp = self::reflectProp($value, 'id');
                 return $rp->isInitialized($value) ? $rp->getValue($value) : null;
             }
             // fallback – try to stringify if object has __toString
@@ -779,11 +809,12 @@ abstract class EntityHelper
      */
     protected function normalizeFk(mixed $fkValue): ?string
     {
-        if ($fkValue === '' || $fkValue === 0 || $fkValue === '0') {
+        if ($fkValue === '' || $fkValue === null || $fkValue === 0 || $fkValue === '0') {
             return null;
         }
 
-        if (is_int($fkValue) || (is_string($fkValue) && ctype_digit($fkValue))) {
+        // Accept any int or non-empty string (supports numeric IDs and UUIDs)
+        if (is_int($fkValue) || is_string($fkValue)) {
             return (string) $fkValue;
         }
 
@@ -796,7 +827,7 @@ abstract class EntityHelper
             return null;
         }
 
-        $rp = new \ReflectionProperty($row, $column);
+        $rp = self::reflectProp($row, $column);
         return $rp->isInitialized($row) ? $rp->getValue($row) : null;
     }
 

--- a/src/Repository/EntityRepository.php
+++ b/src/Repository/EntityRepository.php
@@ -38,9 +38,12 @@ abstract class EntityRepository extends RelationLoader
      */
     public function find(int|string|object $idOrEntity, bool $loadRelations = true): ?object
     {
+        // Fresh context per query to avoid stale references
+        $this->context = new HydrationContext($this->context->maxDepth);
+
         // ☞ accept entity or id
         if (is_object($idOrEntity)) {
-            $rp = new \ReflectionProperty($idOrEntity, 'id');
+            $rp = self::reflectProp($idOrEntity, 'id');
             $id = (string) $rp->getValue($idOrEntity);
         } else {
             $id = (string) $idOrEntity;
@@ -96,6 +99,9 @@ abstract class EntityRepository extends RelationLoader
         int|null $offset = null,
         bool $loadRelations = true
     ): array {
+        // Fresh context per query
+        $this->context = new HydrationContext($this->context->maxDepth);
+
         $qb = clone $this->qb;
         $qb->select()->from($this->table);
 
@@ -117,19 +123,11 @@ abstract class EntityRepository extends RelationLoader
 
         foreach ($entities as $entity) {
             $this->storeOriginalValues($entity);
+        }
 
-            if ($loadRelations) {
-                // Reset context for each root entity to ensure proper depth calculation
-                $entityId = $this->getEntityId($entity);
-                if ($entityId !== null) {
-                    // Register as a root entity with depth 0
-                    $entityClass = get_class($entity);
-                    $this->context->registerInstance($entityClass, $entityId, $entity);
-                    $this->context->setDepth($entity, 0);
-                    // Load relations with guard
-                    $this->loadRelationsWithGuard($entity);
-                }
-            }
+        // Batch-load all relations in a single pass (eliminates N+1)
+        if ($loadRelations && !empty($entities)) {
+            $this->batchLoadRelations($entities);
         }
 
         return $entities;
@@ -145,23 +143,26 @@ abstract class EntityRepository extends RelationLoader
      */
     public function findAll(array $criteria = [], bool $loadRelations = true): array
     {
+        // Fresh context per query
+        $this->context = new HydrationContext($this->context->maxDepth);
+
         $qb = clone $this->qb;
         $qb->select()->from($this->table);
         $criteria = $this->normalizeCriteria($criteria);
         foreach ($criteria as $column => $value) {
             $qb->andWhere($column, '=', $value);
         }
-        $rows = $qb->fetchAll();
-        $entities = array_map(
-            fn($r) => Hydrator::hydrate($this->entityClass, $r),
-            $rows
-        );
+
+        // Use consistent hydration path (same as findBy)
+        $entities = $qb->fetchAll($this->entityClass);
 
         foreach ($entities as $entity) {
             $this->storeOriginalValues($entity);
-            if ($loadRelations) {
-                $this->loadRelations($entity);
-            }
+        }
+
+        // Batch-load all relations in a single pass (eliminates N+1)
+        if ($loadRelations && !empty($entities)) {
+            $this->batchLoadRelations($entities);
         }
 
         return $entities;
@@ -177,7 +178,7 @@ abstract class EntityRepository extends RelationLoader
     public function save(object $entity, bool $partial = true, bool $upsert = false): int|string
     {
         // ——— Check if entity uses UUID
-        $rc = new \ReflectionClass($entity);
+        $rc = self::reflect($entity);
         $isUuid = false;
         $uuidValue = null;
 
@@ -205,7 +206,7 @@ abstract class EntityRepository extends RelationLoader
         // ——— decide update vs insert
         $isUpdate = false;
         if (property_exists($entity, 'id')) {
-            $idProp = new \ReflectionProperty($entity, 'id');
+            $idProp = self::reflectProp($entity, 'id');
             if ($idProp->isInitialized($entity) && $idProp->getValue($entity)) {
                 // For UUID: only consider it an update if we can verify the record exists
                 if ($isUuid) {
@@ -260,7 +261,7 @@ abstract class EntityRepository extends RelationLoader
         // Derive FK column names from entity attributes (fallback if FK metadata is absent)
         $fkColsFromProps = [];
         try {
-            $ref = new \ReflectionClass($entity);
+            $ref = self::reflect($entity);
             foreach ($ref->getProperties() as $prop) {
                 $attrs = $prop->getAttributes(\MonkeysLegion\Entity\Attributes\ManyToOne::class);
                 if (!$attrs) {
@@ -771,7 +772,7 @@ abstract class EntityRepository extends RelationLoader
                         $stmt->execute();
 
                         if (property_exists($entity, 'id')) {
-                            $rp = new \ReflectionProperty($entity, 'id');
+                            $rp = self::reflectProp($entity, 'id');
                             $rp->setValue($entity, $existingId);
                         }
                         $this->storeOriginalValues($entity);
@@ -831,7 +832,7 @@ abstract class EntityRepository extends RelationLoader
         $finalId = $verifyRow->id ?? $id;
 
         if (property_exists($entity, 'id')) {
-            $ref = new \ReflectionProperty($entity, 'id');
+            $ref = self::reflectProp($entity, 'id');
             $ref->setValue($entity, $finalId);
         }
 
@@ -878,7 +879,7 @@ abstract class EntityRepository extends RelationLoader
             if (!property_exists($idOrEntity, 'id')) {
                 throw new InvalidArgumentException('Entity has no id property');
             }
-            $rp = new ReflectionProperty($idOrEntity, 'id');
+            $rp = self::reflectProp($idOrEntity, 'id');
             $id = (string) $rp->getValue($idOrEntity);
 
             // Clean up stored original values
@@ -927,7 +928,7 @@ abstract class EntityRepository extends RelationLoader
      */
     public function findByRelation(string $relationProp, int|string $relatedId): array
     {
-        $rclass = new ReflectionClass($this->entityClass);
+        $rclass = self::reflect($this->entityClass);
 
         if (! $rclass->hasProperty($relationProp)) {
             throw new \InvalidArgumentException("No property $relationProp on {$this->entityClass}");
@@ -955,7 +956,7 @@ abstract class EntityRepository extends RelationLoader
                 );
 
             $targetClass = $relMeta->targetEntity;
-            $tclass      = new ReflectionClass($targetClass);
+            $tclass      = self::reflect($targetClass);
 
             if (! $tclass->hasProperty($otherProp)) {
                 throw new \InvalidArgumentException("No property $otherProp on $targetClass");
@@ -1032,7 +1033,7 @@ abstract class EntityRepository extends RelationLoader
         [$table, $ownCol, $invCol] = $this->getJoinTableMeta($relationProp, $entity);
 
         // retrieve the ID of this entity
-        $ref = new ReflectionProperty($entity::class, 'id');
+        $ref = self::reflectProp($entity::class, 'id');
         $ownId = $ref->getValue($entity);
 
         if (! $ownId) {
@@ -1058,7 +1059,7 @@ abstract class EntityRepository extends RelationLoader
     {
         [$table, $ownCol, $invCol] = $this->getJoinTableMeta($relationProp, $entity);
 
-        $ref = new ReflectionProperty($entity::class, 'id');
+        $ref = self::reflectProp($entity::class, 'id');
         $ownId = $ref->getValue($entity);
 
         return $this->qb
@@ -1077,7 +1078,7 @@ abstract class EntityRepository extends RelationLoader
      */
     protected function syncManyToManyRelations(object $entity): void
     {
-        $rc = new \ReflectionClass($entity);
+        $rc = self::reflect($entity);
         $entityId = $this->getEntityId($entity);
         
         if (!$entityId) {

--- a/src/Repository/RelationLoader.php
+++ b/src/Repository/RelationLoader.php
@@ -52,7 +52,7 @@ abstract class RelationLoader extends EntityHelper
             $this->context->setDepth($entity, 0);
         }
 
-        $ref = new ReflectionClass($entity);
+        $ref = self::reflect($entity);
 
         foreach ($ref->getProperties() as $prop) {
             // Handle ManyToOne relationships
@@ -116,7 +116,7 @@ abstract class RelationLoader extends EntityHelper
             return;
         }
 
-        $ref = new ReflectionClass($entity);
+        $ref = self::reflect($entity);
 
         foreach ($ref->getProperties() as $prop) {
             $isCollectionRelation = false;
@@ -203,16 +203,7 @@ abstract class RelationLoader extends EntityHelper
             return;
         }
 
-        $qb = clone $this->qb;
-        $row = $qb->select(['t.*'])
-            ->from($targetTable, 't')
-            ->where("t.id", '=', $fkValue)
-            ->fetch($targetClass);
-        if ($row) {
-            $this->safeSetProperty($prop, $entity, $this->context->getInstance($targetClass, $fkValue));
-            return;
-        }
-
+        // Single query (previously duplicated)
         $qb = clone $this->qb;
         $row = $qb->select(['t.*'])
             ->from($targetTable, 't')
@@ -765,5 +756,324 @@ abstract class RelationLoader extends EntityHelper
         }
 
         $prop->setValue($entity, $value);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  BATCH RELATION LOADING — eliminates N+1 for findBy / findAll
+    // ════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Load all relations for a collection of entities using batched queries.
+     *
+     * Instead of N queries per relation (one per entity), this issues a single
+     * WHERE … IN (…) query per relation type and distributes results back.
+     *
+     * @param object[] $entities  Hydrated root entities (same class)
+     */
+    protected function batchLoadRelations(array $entities): void
+    {
+        if (empty($entities)) {
+            return;
+        }
+
+        // Register root entities in context
+        foreach ($entities as $entity) {
+            $entityId = $this->getEntityId($entity);
+            if ($entityId === null) {
+                continue;
+            }
+            $entityClass = get_class($entity);
+            if (!$this->context->hasInstance($entityClass, $entityId)) {
+                $this->context->registerInstance($entityClass, $entityId, $entity);
+                $this->context->setDepth($entity, 0);
+            }
+        }
+
+        $ref = self::reflect($entities[0]);
+
+        foreach ($ref->getProperties() as $prop) {
+            try {
+                // ManyToOne — batch by FK
+                if ($manyToOneAttrs = $prop->getAttributes(ManyToOne::class)) {
+                    $attr = $manyToOneAttrs[0]->newInstance();
+                    $this->batchLoadManyToOne($entities, $prop, $attr);
+                }
+
+                // OneToOne owning side — same as ManyToOne
+                if ($oneToOneAttrs = $prop->getAttributes(OneToOne::class)) {
+                    $attr = $oneToOneAttrs[0]->newInstance();
+                    if (!$attr->mappedBy) {
+                        $this->batchLoadManyToOne($entities, $prop, new ManyToOne(
+                            targetEntity: $attr->targetEntity,
+                            inversedBy: $attr->inversedBy,
+                            nullable: $attr->nullable
+                        ));
+                    } else {
+                        // Inverse side: fall back to per-entity loading (rare)
+                        foreach ($entities as $entity) {
+                            if ($this->canGoDeeper($entity)) {
+                                $this->loadOneToOneInverse($entity, $prop, $attr);
+                            }
+                        }
+                    }
+                }
+
+                // OneToMany — batch by parent IDs
+                if ($oneToManyAttrs = $prop->getAttributes(OneToMany::class)) {
+                    $attr = $oneToManyAttrs[0]->newInstance();
+                    $this->batchLoadOneToMany($entities, $prop, $attr);
+                }
+
+                // ManyToMany — batch via join table
+                if ($manyToManyAttrs = $prop->getAttributes(ManyToMany::class)) {
+                    $attr = $manyToManyAttrs[0]->newInstance();
+                    $this->batchLoadManyToMany($entities, $prop, $attr);
+                }
+            } catch (\Exception $e) {
+                error_log("Batch relation load failed for {$prop->getName()}: " . $e->getMessage());
+                // Fallback: set default value
+                $isCollection = $prop->getAttributes(OneToMany::class) || $prop->getAttributes(ManyToMany::class);
+                foreach ($entities as $entity) {
+                    $this->safeSetProperty($prop, $entity, $isCollection ? [] : null);
+                }
+            }
+        }
+    }
+
+    /**
+     * Batch-load ManyToOne/OneToOne(owning) relations.
+     *
+     * Collects all FK values from $entities, loads target entities with a
+     * single WHERE id IN (...) query, then assigns them back.
+     */
+    private function batchLoadManyToOne(array $entities, ReflectionProperty $prop, ManyToOne $attr): void
+    {
+        $fkColumn    = $this->getRelationColumnName($prop->getName());
+        $targetClass = $attr->targetEntity;
+        $targetTable = $this->tableOf($targetClass);
+
+        // 1) Collect unique FK values
+        $fkValues = [];
+        foreach ($entities as $entity) {
+            if (!$this->canGoDeeper($entity)) {
+                $this->safeSetProperty($prop, $entity, null);
+                continue;
+            }
+            $fkValue = $this->getEntityPropValue($entity, $fkColumn);
+            $fkValue = $this->normalizeFk($fkValue);
+            if ($fkValue !== null && !$this->context->hasInstance($targetClass, $fkValue)) {
+                $fkValues[$fkValue] = true;
+            }
+        }
+
+        // 2) Batch-fetch missing target entities
+        $uniqueFks = array_keys($fkValues);
+        if (!empty($uniqueFks)) {
+            // Build WHERE id IN (...) with parameter binding
+            $placeholders = implode(',', array_fill(0, count($uniqueFks), '?'));
+            $pdo = $this->qb->pdo();
+            $sql = "SELECT * FROM {$targetTable} WHERE id IN ({$placeholders})";
+            $stmt = $pdo->prepare($sql);
+            $stmt->execute(array_values($uniqueFks));
+            $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+            foreach ($rows as $row) {
+                $relatedEntity = \MonkeysLegion\Entity\Hydrator::hydrate($targetClass, $row);
+                $relatedId = (string) ($row['id'] ?? '');
+                if ($relatedId !== '' && !$this->context->hasInstance($targetClass, $relatedId)) {
+                    $this->context->registerInstance($targetClass, $relatedId, $relatedEntity);
+                    $this->context->setDepth($relatedEntity, 1);
+                }
+            }
+        }
+
+        // 3) Assign from context
+        foreach ($entities as $entity) {
+            if (!$this->canGoDeeper($entity)) {
+                continue; // already set to null above
+            }
+            $fkValue = $this->normalizeFk($this->getEntityPropValue($entity, $fkColumn));
+            if ($fkValue === null) {
+                $this->safeSetProperty($prop, $entity, null);
+                continue;
+            }
+            $related = $this->context->getInstance($targetClass, $fkValue);
+            $this->safeSetProperty($prop, $entity, $related);
+        }
+
+        // 4) Recursively load deeper relations for newly loaded entities
+        foreach ($uniqueFks as $fk) {
+            $instance = $this->context->getInstance($targetClass, $fk);
+            if ($instance && $this->canGoDeeper($instance)) {
+                $this->loadRelationsWithGuard($instance);
+            }
+        }
+    }
+
+    /**
+     * Batch-load OneToMany relations.
+     *
+     * Issues a single SELECT … WHERE fk_col IN (...) to load all children,
+     * then groups and distributes them by parent ID.
+     */
+    private function batchLoadOneToMany(array $entities, ReflectionProperty $prop, OneToMany $attr): void
+    {
+        if (!$attr->mappedBy) {
+            foreach ($entities as $entity) {
+                $this->safeSetProperty($prop, $entity, []);
+            }
+            return;
+        }
+
+        $targetClass = $attr->targetEntity;
+        $targetTable = $this->tableOf($targetClass);
+        $fkColumn    = $this->getRelationColumnName($attr->mappedBy, $targetTable);
+
+        // Collect parent IDs
+        $parentIds = [];
+        foreach ($entities as $entity) {
+            if (!$this->canGoDeeper($entity)) {
+                $this->safeSetProperty($prop, $entity, []);
+                continue;
+            }
+            $eid = $this->getEntityId($entity);
+            if ($eid !== null) {
+                $parentIds[$eid] = true;
+            }
+        }
+
+        if (empty($parentIds)) {
+            return;
+        }
+
+        $uniqueParentIds = array_keys($parentIds);
+        $placeholders = implode(',', array_fill(0, count($uniqueParentIds), '?'));
+        $pdo = $this->qb->pdo();
+        $sql = "SELECT * FROM {$targetTable} WHERE {$fkColumn} IN ({$placeholders})";
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute(array_values($uniqueParentIds));
+        $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        // Group children by FK value
+        $grouped = [];
+        foreach ($rows as $row) {
+            $childEntity = \MonkeysLegion\Entity\Hydrator::hydrate($targetClass, $row);
+            $childId = (string) ($row['id'] ?? '');
+            $parentFk = (string) ($row[$fkColumn] ?? '');
+
+            if ($childId !== '' && !$this->context->hasInstance($targetClass, $childId)) {
+                $this->context->registerInstance($targetClass, $childId, $childEntity);
+                $this->context->setDepth($childEntity, 1);
+            } elseif ($childId !== '') {
+                $childEntity = $this->context->getInstance($targetClass, $childId) ?? $childEntity;
+            }
+
+            $grouped[$parentFk][] = $childEntity;
+        }
+
+        // Assign grouped children to parent entities
+        foreach ($entities as $entity) {
+            $eid = $this->getEntityId($entity);
+            $children = $grouped[$eid] ?? [];
+            $this->safeSetProperty($prop, $entity, $children);
+        }
+
+        // Recursively load deeper relations for children
+        foreach ($rows as $row) {
+            $childId = (string) ($row['id'] ?? '');
+            if ($childId !== '') {
+                $instance = $this->context->getInstance($targetClass, $childId);
+                if ($instance && $this->canGoDeeper($instance)) {
+                    $this->loadRelationsWithGuard($instance);
+                }
+            }
+        }
+    }
+
+    /**
+     * Batch-load ManyToMany relations.
+     *
+     * Joins through the pivot table with a single WHERE own_col IN (...)
+     * and distributes results by owning entity ID.
+     */
+    private function batchLoadManyToMany(array $entities, ReflectionProperty $prop, ManyToMany $attr): void
+    {
+        // Collect entity IDs
+        $entityIds = [];
+        foreach ($entities as $entity) {
+            if (!$this->canGoDeeper($entity)) {
+                $this->safeSetProperty($prop, $entity, []);
+                continue;
+            }
+            $eid = $this->getEntityId($entity);
+            if ($eid !== null) {
+                $entityIds[$eid] = true;
+            }
+        }
+
+        if (empty($entityIds)) {
+            return;
+        }
+
+        try {
+            [$jt, $ownCol, $invCol] = $this->getJoinTableMeta($prop->getName(), $entities[0]);
+        } catch (\Exception $e) {
+            foreach ($entities as $entity) {
+                $this->safeSetProperty($prop, $entity, []);
+            }
+            return;
+        }
+
+        $targetClass = $attr->targetEntity;
+        $targetTable = $this->tableOf($targetClass);
+
+        $uniqueIds = array_keys($entityIds);
+        $placeholders = implode(',', array_fill(0, count($uniqueIds), '?'));
+        $pdo = $this->qb->pdo();
+
+        // Single join query fetches all related records for all parent entities
+        $sql = "SELECT t.*, j.{$ownCol} AS __pivot_owner_id
+                FROM {$targetTable} t
+                JOIN {$jt} j ON j.{$invCol} = t.id
+                WHERE j.{$ownCol} IN ({$placeholders})";
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute(array_values($uniqueIds));
+        $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        // Group by owning entity
+        $grouped = [];
+        foreach ($rows as $row) {
+            $ownerId = (string) ($row['__pivot_owner_id'] ?? '');
+            unset($row['__pivot_owner_id']);
+
+            $childEntity = \MonkeysLegion\Entity\Hydrator::hydrate($targetClass, $row);
+            $childId = (string) ($row['id'] ?? '');
+
+            if ($childId !== '' && !$this->context->hasInstance($targetClass, $childId)) {
+                $this->context->registerInstance($targetClass, $childId, $childEntity);
+                $this->context->setDepth($childEntity, 1);
+            } elseif ($childId !== '') {
+                $childEntity = $this->context->getInstance($targetClass, $childId) ?? $childEntity;
+            }
+
+            $grouped[$ownerId][] = $childEntity;
+        }
+
+        // Assign
+        foreach ($entities as $entity) {
+            $eid = $this->getEntityId($entity);
+            $this->safeSetProperty($prop, $entity, $grouped[$eid] ?? []);
+        }
+
+        // Recursively load deeper relations for related entities
+        foreach ($rows as $row) {
+            $childId = (string) ($row['id'] ?? '');
+            if ($childId !== '') {
+                $instance = $this->context->getInstance($targetClass, $childId);
+                if ($instance && $this->canGoDeeper($instance)) {
+                    $this->loadRelationsWithGuard($instance);
+                }
+            }
+        }
     }
 }

--- a/src/Repository/RelationLoader.php
+++ b/src/Repository/RelationLoader.php
@@ -845,34 +845,89 @@ abstract class RelationLoader extends EntityHelper
      *
      * Collects all FK values from $entities, loads target entities with a
      * single WHERE id IN (...) query, then assigns them back.
+     *
+     * If an entity does not expose the FK column as a hydrated property
+     * (e.g. `?Author $author` without `author_id`), the FK is fetched
+     * from the owning table in a single batched query — matching the
+     * fallback behaviour of the non-batch loader.
      */
     private function batchLoadManyToOne(array $entities, ReflectionProperty $prop, ManyToOne $attr): void
     {
         $fkColumn    = $this->getRelationColumnName($prop->getName());
         $targetClass = $attr->targetEntity;
         $targetTable = $this->tableOf($targetClass);
+        $owningTable = $this->tableOf(get_class($entities[0]));
 
-        // 1) Collect unique FK values
-        $fkValues = [];
+        $qi = fn(string $id): string => $this->qb->quoteIdentifier($id);
+
+        // 1) Collect FK values — track entities that don't expose the FK property
+        $fkValues          = [];         // unique FK values to load
+        $entityFkMap       = [];         // spl_object_id => normalised FK
+        $entitiesMissingFk = [];         // spl_object_id => entity (FK not on the object)
+        $idsNeedingLookup  = [];         // owning-table IDs whose FK must be fetched from DB
+
         foreach ($entities as $entity) {
             if (!$this->canGoDeeper($entity)) {
                 $this->safeSetProperty($prop, $entity, null);
                 continue;
             }
+
+            $oid     = spl_object_id($entity);
             $fkValue = $this->getEntityPropValue($entity, $fkColumn);
             $fkValue = $this->normalizeFk($fkValue);
-            if ($fkValue !== null && !$this->context->hasInstance($targetClass, $fkValue)) {
-                $fkValues[$fkValue] = true;
+
+            if ($fkValue !== null) {
+                $entityFkMap[$oid] = $fkValue;
+                if (!$this->context->hasInstance($targetClass, $fkValue)) {
+                    $fkValues[$fkValue] = true;
+                }
+            } else {
+                // FK not present on the hydrated entity — queue for DB lookup
+                $entitiesMissingFk[$oid] = $entity;
+                $idValue = $this->getEntityId($entity);
+                if ($idValue !== null) {
+                    $idsNeedingLookup[] = $idValue;
+                }
+            }
+        }
+
+        // 1b) Batch-fetch missing FK values from the owning table
+        if (!empty($idsNeedingLookup)) {
+            $placeholders = implode(',', array_fill(0, count($idsNeedingLookup), '?'));
+            $pdo  = $this->qb->pdo();
+            $sql  = "SELECT {$qi('id')}, {$qi($fkColumn)} FROM {$qi($owningTable)} WHERE {$qi('id')} IN ({$placeholders})";
+            $stmt = $pdo->prepare($sql);
+            $stmt->execute(array_values($idsNeedingLookup));
+            $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+            $fkById = [];
+            foreach ($rows as $row) {
+                $rowId = $row['id'] ?? null;
+                $rowFk = $this->normalizeFk($row[$fkColumn] ?? null);
+                if ($rowId !== null && $rowFk !== null) {
+                    $fkById[(string) $rowId] = $rowFk;
+                }
+            }
+
+            foreach ($entitiesMissingFk as $oid => $entity) {
+                $idKey = $this->getEntityId($entity);
+                if ($idKey === null || !isset($fkById[$idKey])) {
+                    continue;
+                }
+                $fk = $fkById[$idKey];
+                $entityFkMap[$oid] = $fk;
+                if (!$this->context->hasInstance($targetClass, $fk)) {
+                    $fkValues[$fk] = true;
+                }
             }
         }
 
         // 2) Batch-fetch missing target entities
         $uniqueFks = array_keys($fkValues);
         if (!empty($uniqueFks)) {
-            // Build WHERE id IN (...) with parameter binding
             $placeholders = implode(',', array_fill(0, count($uniqueFks), '?'));
-            $pdo = $this->qb->pdo();
-            $sql = "SELECT * FROM {$targetTable} WHERE id IN ({$placeholders})";
+            $pdo  = $this->qb->pdo();
+            $sql  = "SELECT * FROM {$qi($targetTable)} WHERE {$qi('id')} IN ({$placeholders})";
             $stmt = $pdo->prepare($sql);
             $stmt->execute(array_values($uniqueFks));
             $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
@@ -892,7 +947,8 @@ abstract class RelationLoader extends EntityHelper
             if (!$this->canGoDeeper($entity)) {
                 continue; // already set to null above
             }
-            $fkValue = $this->normalizeFk($this->getEntityPropValue($entity, $fkColumn));
+            $oid     = spl_object_id($entity);
+            $fkValue = $entityFkMap[$oid] ?? null;
             if ($fkValue === null) {
                 $this->safeSetProperty($prop, $entity, null);
                 continue;
@@ -949,7 +1005,8 @@ abstract class RelationLoader extends EntityHelper
         $uniqueParentIds = array_keys($parentIds);
         $placeholders = implode(',', array_fill(0, count($uniqueParentIds), '?'));
         $pdo = $this->qb->pdo();
-        $sql = "SELECT * FROM {$targetTable} WHERE {$fkColumn} IN ({$placeholders})";
+        $qi  = fn(string $id): string => $this->qb->quoteIdentifier($id);
+        $sql = "SELECT * FROM {$qi($targetTable)} WHERE {$qi($fkColumn)} IN ({$placeholders})";
         $stmt = $pdo->prepare($sql);
         $stmt->execute(array_values($uniqueParentIds));
         $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
@@ -1030,12 +1087,13 @@ abstract class RelationLoader extends EntityHelper
         $uniqueIds = array_keys($entityIds);
         $placeholders = implode(',', array_fill(0, count($uniqueIds), '?'));
         $pdo = $this->qb->pdo();
+        $qi  = fn(string $id): string => $this->qb->quoteIdentifier($id);
 
         // Single join query fetches all related records for all parent entities
-        $sql = "SELECT t.*, j.{$ownCol} AS __pivot_owner_id
-                FROM {$targetTable} t
-                JOIN {$jt} j ON j.{$invCol} = t.id
-                WHERE j.{$ownCol} IN ({$placeholders})";
+        $sql = "SELECT t.*, j.{$qi($ownCol)} AS __pivot_owner_id
+                FROM {$qi($targetTable)} t
+                JOIN {$qi($jt)} j ON j.{$qi($invCol)} = t.{$qi('id')}
+                WHERE j.{$qi($ownCol)} IN ({$placeholders})";
         $stmt = $pdo->prepare($sql);
         $stmt->execute(array_values($uniqueIds));
         $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);

--- a/tests/Integration/BatchHydrationTest.php
+++ b/tests/Integration/BatchHydrationTest.php
@@ -1,0 +1,303 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use MonkeysLegion\Query\QueryBuilder;
+use MonkeysLegion\Repository\EntityRepository;
+use MonkeysLegion\Database\Contracts\ConnectionInterface;
+use MonkeysLegion\Entity\Attributes\Field;
+use MonkeysLegion\Entity\Attributes\ManyToOne;
+use MonkeysLegion\Entity\Attributes\OneToMany;
+use MonkeysLegion\Entity\Attributes\ManyToMany;
+use MonkeysLegion\Entity\Attributes\JoinTable;
+use MonkeysLegion\Entity\Attributes\Entity;
+
+// ──────────────────────────────────────────────────────────────
+//  Test entities (unique namespace-safe names to avoid collisions
+//  with other integration test files)
+// ──────────────────────────────────────────────────────────────
+
+#[Entity(table: 'batch_publishers')]
+class BatchPublisher
+{
+    #[Field(type: 'int', primaryKey: true)]
+    public ?int $id = null;
+
+    #[Field(type: 'string')]
+    public string $name = '';
+
+    /** @var BatchArticle[] */
+    #[OneToMany(targetEntity: BatchArticle::class, mappedBy: 'publisher')]
+    public array $articles = [];
+
+    /** @var BatchCategory[] */
+    #[ManyToMany(
+        targetEntity: BatchCategory::class,
+        inversedBy: 'publishers',
+        joinTable: new JoinTable(
+            name: 'batch_publisher_category',
+            joinColumn: 'publisher_id',
+            inverseColumn: 'category_id'
+        )
+    )]
+    public array $categories = [];
+}
+
+#[Entity(table: 'batch_articles')]
+class BatchArticle
+{
+    #[Field(type: 'int', primaryKey: true)]
+    public ?int $id = null;
+
+    #[Field(type: 'string')]
+    public string $title = '';
+
+    #[ManyToOne(targetEntity: BatchPublisher::class, inversedBy: 'articles')]
+    public ?BatchPublisher $publisher = null;
+}
+
+#[Entity(table: 'batch_categories')]
+class BatchCategory
+{
+    #[Field(type: 'int', primaryKey: true)]
+    public ?int $id = null;
+
+    #[Field(type: 'string')]
+    public string $label = '';
+
+    /** @var BatchPublisher[] */
+    #[ManyToMany(targetEntity: BatchPublisher::class, mappedBy: 'categories')]
+    public array $publishers = [];
+}
+
+class BatchPublisherRepository extends EntityRepository
+{
+    protected string $table = 'batch_publishers';
+    protected string $entityClass = BatchPublisher::class;
+}
+
+class BatchArticleRepository extends EntityRepository
+{
+    protected string $table = 'batch_articles';
+    protected string $entityClass = BatchArticle::class;
+}
+
+class BatchCategoryRepository extends EntityRepository
+{
+    protected string $table = 'batch_categories';
+    protected string $entityClass = BatchCategory::class;
+}
+
+/**
+ * Integration tests for batched relation loading via findBy / findAll.
+ *
+ * These tests verify the batch hydration code paths that were added to
+ * eliminate N+1 queries when loading ManyToOne, OneToMany, and ManyToMany
+ * relations for collections of entities.
+ */
+class BatchHydrationTest extends TestCase
+{
+    private \PDO $pdo;
+    private QueryBuilder $qb;
+    private BatchPublisherRepository $publisherRepo;
+    private BatchArticleRepository $articleRepo;
+    private BatchCategoryRepository $categoryRepo;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new \PDO('sqlite::memory:');
+        $this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $this->pdo->exec('
+            CREATE TABLE batch_publishers (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL
+            )
+        ');
+
+        $this->pdo->exec('
+            CREATE TABLE batch_articles (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT NOT NULL,
+                publisher_id INTEGER,
+                FOREIGN KEY (publisher_id) REFERENCES batch_publishers(id)
+            )
+        ');
+
+        $this->pdo->exec('
+            CREATE TABLE batch_categories (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                label TEXT NOT NULL
+            )
+        ');
+
+        $this->pdo->exec('
+            CREATE TABLE batch_publisher_category (
+                publisher_id INTEGER NOT NULL,
+                category_id INTEGER NOT NULL,
+                PRIMARY KEY (publisher_id, category_id),
+                FOREIGN KEY (publisher_id) REFERENCES batch_publishers(id),
+                FOREIGN KEY (category_id) REFERENCES batch_categories(id)
+            )
+        ');
+
+        // Seed data: 3 publishers, 5 articles, 3 categories, pivot entries
+        $this->pdo->exec("INSERT INTO batch_publishers (name) VALUES ('Pub A'), ('Pub B'), ('Pub C')");
+        $this->pdo->exec("INSERT INTO batch_articles (title, publisher_id) VALUES
+            ('Art 1', 1), ('Art 2', 1), ('Art 3', 2), ('Art 4', 2), ('Art 5', NULL)");
+        $this->pdo->exec("INSERT INTO batch_categories (label) VALUES ('Cat X'), ('Cat Y'), ('Cat Z')");
+        $this->pdo->exec("INSERT INTO batch_publisher_category (publisher_id, category_id) VALUES
+            (1, 1), (1, 2), (2, 2), (2, 3)");
+
+        $pdo  = $this->pdo;
+        $conn = new class($pdo) implements ConnectionInterface {
+            public function __construct(private \PDO $pdo) {}
+            public function pdo(): \PDO { return $this->pdo; }
+            public function connect(): void {}
+            public function disconnect(): void {}
+            public function isConnected(): bool { return true; }
+            public function getDsn(): string { return ''; }
+            public function isAlive(): bool { return true; }
+        };
+
+        $this->qb            = new QueryBuilder($conn);
+        $this->publisherRepo = new BatchPublisherRepository($this->qb);
+        $this->articleRepo   = new BatchArticleRepository($this->qb);
+        $this->categoryRepo  = new BatchCategoryRepository($this->qb);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->pdo->exec('DELETE FROM batch_publisher_category');
+        $this->pdo->exec('DELETE FROM batch_articles');
+        $this->pdo->exec('DELETE FROM batch_categories');
+        $this->pdo->exec('DELETE FROM batch_publishers');
+    }
+
+    // ==================== findBy — ManyToOne batch ====================
+
+    public function testFindByBatchesManyToOneRelations(): void
+    {
+        // findBy should batch-load the publisher relation for all articles
+        $articles = $this->articleRepo->findBy([], ['id' => 'ASC'], null, null, true);
+
+        $this->assertCount(5, $articles);
+
+        // Articles 1 & 2 → Pub A
+        $this->assertNotNull($articles[0]->publisher);
+        $this->assertEquals('Pub A', $articles[0]->publisher->name);
+        $this->assertNotNull($articles[1]->publisher);
+        $this->assertEquals('Pub A', $articles[1]->publisher->name);
+
+        // Articles 3 & 4 → Pub B
+        $this->assertNotNull($articles[2]->publisher);
+        $this->assertEquals('Pub B', $articles[2]->publisher->name);
+        $this->assertNotNull($articles[3]->publisher);
+        $this->assertEquals('Pub B', $articles[3]->publisher->name);
+
+        // Article 5 → no publisher
+        $this->assertNull($articles[4]->publisher);
+
+        // Object identity: articles sharing same publisher should get the same instance
+        $this->assertSame($articles[0]->publisher, $articles[1]->publisher);
+        $this->assertSame($articles[2]->publisher, $articles[3]->publisher);
+    }
+
+    // ==================== findAll — OneToMany batch ====================
+
+    public function testFindAllBatchesOneToManyRelations(): void
+    {
+        $publishers = $this->publisherRepo->findAll([], true);
+
+        $this->assertCount(3, $publishers);
+
+        // Sort by id for deterministic ordering
+        usort($publishers, fn($a, $b) => $a->id <=> $b->id);
+
+        // Pub A → 2 articles
+        $this->assertIsArray($publishers[0]->articles);
+        $this->assertCount(2, $publishers[0]->articles);
+
+        // Pub B → 2 articles
+        $this->assertIsArray($publishers[1]->articles);
+        $this->assertCount(2, $publishers[1]->articles);
+
+        // Pub C → 0 articles
+        $this->assertIsArray($publishers[2]->articles);
+        $this->assertCount(0, $publishers[2]->articles);
+    }
+
+    // ==================== findAll — ManyToMany batch ====================
+
+    public function testFindAllBatchesManyToManyRelations(): void
+    {
+        $publishers = $this->publisherRepo->findAll([], true);
+
+        usort($publishers, fn($a, $b) => $a->id <=> $b->id);
+
+        // Pub A → Cat X, Cat Y
+        $this->assertIsArray($publishers[0]->categories);
+        $this->assertCount(2, $publishers[0]->categories);
+        $catIds = array_map(fn($c) => $c->id, $publishers[0]->categories);
+        sort($catIds);
+        $this->assertEquals([1, 2], $catIds);
+
+        // Pub B → Cat Y, Cat Z
+        $this->assertIsArray($publishers[1]->categories);
+        $this->assertCount(2, $publishers[1]->categories);
+        $catIds = array_map(fn($c) => $c->id, $publishers[1]->categories);
+        sort($catIds);
+        $this->assertEquals([2, 3], $catIds);
+
+        // Pub C → none
+        $this->assertIsArray($publishers[2]->categories);
+        $this->assertCount(0, $publishers[2]->categories);
+    }
+
+    // ==================== findBy with criteria — batch still works ====================
+
+    public function testFindByWithCriteriaBatchesRelations(): void
+    {
+        // Only fetch articles belonging to publisher 1
+        $articles = $this->articleRepo->findBy(
+            ['publisher_id' => 1],
+            ['id' => 'ASC'],
+            null,
+            null,
+            true
+        );
+
+        $this->assertCount(2, $articles);
+        $this->assertNotNull($articles[0]->publisher);
+        $this->assertEquals('Pub A', $articles[0]->publisher->name);
+        $this->assertSame($articles[0]->publisher, $articles[1]->publisher);
+    }
+
+    // ==================== findBy with limit — batch works for subset ====================
+
+    public function testFindByWithLimitBatchesRelations(): void
+    {
+        $articles = $this->articleRepo->findBy([], ['id' => 'ASC'], 2, 0, true);
+
+        $this->assertCount(2, $articles);
+        // Both should have publisher loaded
+        $this->assertNotNull($articles[0]->publisher);
+        $this->assertNotNull($articles[1]->publisher);
+    }
+
+    // ==================== findAll with no relations loaded ====================
+
+    public function testFindAllWithoutRelationsDoesNotLoad(): void
+    {
+        $articles = $this->articleRepo->findAll([], false);
+
+        $this->assertCount(5, $articles);
+        // Publisher should NOT be loaded when loadRelations=false
+        foreach ($articles as $article) {
+            $this->assertNull($article->publisher);
+        }
+    }
+}


### PR DESCRIPTION
- Replace N+1 per-entity relation loading with batch WHERE IN queries (batchLoadManyToOne, batchLoadOneToMany, batchLoadManyToMany)
- Add static ReflectionClass/ReflectionProperty caching across all repos
- Fix normalizeFk() to support UUID-based foreign keys (was silently broken)
- Fix duplicate query in loadOneToOneInverse
- Reset HydrationContext per find/findBy/findAll call (prevents stale refs)
- Unify findAll hydration path with findBy (fetchAll with entity class)
- Add tableOf() result caching

50 entities × 4 relations: ~200 queries → ~5 queries